### PR TITLE
Fix patch for C++ flags

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/root-x.xx.xx-osx-remove-hardcoded-sysroot.patch  # [osx]
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win]
   features:
     - blas_{{ variant }}

--- a/recipe/patches/root-6.18.00_root_config_cxxstd_flags.patch
+++ b/recipe/patches/root-6.18.00_root_config_cxxstd_flags.patch
@@ -6,7 +6,7 @@ index c18d4d719d..8c367d4a35 100644
  set(configfeatures ${features})
  set(configargs ${ROOT_CONFIGARGS})
  set(configoptions ${ROOT_CONFIGARGS})
-+set(configstd ${CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION})
++set(configstd ${CMAKE_CXX17_STANDARD_COMPILE_OPTION})
  get_filename_component(altcc ${CMAKE_C_COMPILER} NAME)
  get_filename_component(altcxx ${CMAKE_CXX_COMPILER} NAME)
  get_filename_component(altf77 "${CMAKE_Fortran_COMPILER}" NAME)


### PR DESCRIPTION
This repairs an issue with root-config not reporting the CXX standard, as reported on mattermost. It was caused by applying a 6.18 patch to 6.16 incorrectly. For now, the CXX standard is just hardcoded at C++17, and then in 6.18 the patch will no longer be needed.