### PR TITLE
Pin libcxx version on macOS to avoid C++ header mismatches in allDict.cxx.pch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     - patches/root-x.xx.xx-osx-remove-hardcoded-sysroot.patch  # [osx]
 
 build:
-  number: 12
+  number: 13
   skip: True  # [win]
   features:
   run_exports:
@@ -105,6 +105,9 @@ requirements:
     - xrootd
     - xz
     - zlib
+    # FIXME: The generated allDict.cxx.pch is dependent on versin of the C++ headers used
+    # As it is shipped in the macOS binaries we have to use the same one as in the compilers package
+    - libcxx =4  # [osx]
   run:
     - compilers
     - {{ pin_compatible('numpy') }}
@@ -138,6 +141,8 @@ requirements:
     - xorg-libxft  # [linux]
     - xorg-libxpm  # [linux]
     - xrootd
+    # FIXME: See comment at end of host requirements
+    - libcxx =4  # [osx]
   run_constrained:
     # Items listed here conflict with ROOT
     # FIXME Add support in ROOT for building with an external cling


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The CMS fireworks build (https://github.com/conda-forge/staged-recipes/pull/8199) has issues because `libcxx=8.0` is being used to generate the PCH on macOS. As the compilers depend on `libcxx=4.0` this ends up mismatching. As a temporary workaround I've pinned it in the `host` dependencies.