### PR TITLE
Remove -fno-merge-constants from macOS builds

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -12,3 +12,6 @@ provider:
 os_version:
   linux_64: cos7
 test_on_native_only: true
+bot:
+  abi_migration_branches:
+    - 6.24

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -x
 
-# Conda's binary relocation can result in string changing which can result in errors like
-#   > $ root.exe -l -b -q -x root-feedstock/recipe/test.cpp++
-#   > powerpc64le-conda-linux-gnu-c++: error: missing filename after '-o'
-# https://gitter.im/conda-forge/conda-forge.github.io?at=61e18f469a3354540621b912
-export CXXFLAGS="${CXXFLAGS} -fno-merge-constants"
-export CFLAGS="${CFLAGS} -fno-merge-constants"
+if [[ "${target_platform}" == "linux-"* ]]; then
+  # Conda's binary relocation can result in string changing which can result in errors like
+  #   > $ root.exe -l -b -q -x root-feedstock/recipe/test.cpp++
+  #   > powerpc64le-conda-linux-gnu-c++: error: missing filename after '-o'
+  # https://gitter.im/conda-forge/conda-forge.github.io?at=61e18f469a3354540621b912
+  export CXXFLAGS="${CXXFLAGS} -fno-merge-constants"
+  export CFLAGS="${CFLAGS} -fno-merge-constants"
+fi
 
 # https://github.com/conda-forge/root-feedstock/issues/160
 export CXXFLAGS="${CXXFLAGS} -D__ROOFIT_NOBANNER"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "root" %}
 {% set tag_name = "6-26-00" %}
 {% set version = ".".join(tag_name.split("-")|map("int")|map("string")) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set clang_version = "9.0.1" %}
 {% set clang_patches_version = "root_62600" %}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
