### PR TITLE
Apply Python 3.11 migration

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,11 +8,6 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.20openssl1.1.1python3.7.____cpython:
-        CONFIG: linux_64_numpy1.20openssl1.1.1python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.20openssl1.1.1pytho_h03b43dd402
       linux_64_numpy1.20openssl1.1.1python3.8.____cpython:
         CONFIG: linux_64_numpy1.20openssl1.1.1python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -23,11 +18,6 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_64_numpy1.20openssl1.1.1pytho_h90f93beee8
-      linux_64_numpy1.20openssl3python3.7.____cpython:
-        CONFIG: linux_64_numpy1.20openssl3python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.20openssl3python3.7.____cpython
       linux_64_numpy1.20openssl3python3.8.____cpython:
         CONFIG: linux_64_numpy1.20openssl3python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -48,11 +38,16 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_64_numpy1.21openssl3python3.10.____cpython
-      linux_aarch64_numpy1.20openssl1.1.1python3.7.____cpython:
-        CONFIG: linux_aarch64_numpy1.20openssl1.1.1python3.7.____cpython
+      linux_64_numpy1.23openssl1.1.1python3.11.____cpython:
+        CONFIG: linux_64_numpy1.23openssl1.1.1python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.20openssl1.1.1_ha1473d16a5
+        SHORT_CONFIG: linux_64_numpy1.23openssl1.1.1pytho_hb1b66b3008
+      linux_64_numpy1.23openssl3python3.11.____cpython:
+        CONFIG: linux_64_numpy1.23openssl3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_numpy1.23openssl3python3.11.____cpython
       linux_aarch64_numpy1.20openssl1.1.1python3.8.____cpython:
         CONFIG: linux_aarch64_numpy1.20openssl1.1.1python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -63,11 +58,6 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_aarch64_numpy1.20openssl1.1.1_h49d3bb948f
-      linux_aarch64_numpy1.20openssl3python3.7.____cpython:
-        CONFIG: linux_aarch64_numpy1.20openssl3python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_aarch64_numpy1.20openssl3pyth_h8fae17d8b0
       linux_aarch64_numpy1.20openssl3python3.8.____cpython:
         CONFIG: linux_aarch64_numpy1.20openssl3python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -88,11 +78,16 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_aarch64_numpy1.21openssl3pyth_h9360ca082d
-      linux_ppc64le_numpy1.20openssl1.1.1python3.7.____cpython:
-        CONFIG: linux_ppc64le_numpy1.20openssl1.1.1python3.7.____cpython
+      linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython:
+        CONFIG: linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_ppc64le_numpy1.20openssl1.1.1_h282c6eb063
+        SHORT_CONFIG: linux_aarch64_numpy1.23openssl1.1.1_he223b53bb7
+      linux_aarch64_numpy1.23openssl3python3.11.____cpython:
+        CONFIG: linux_aarch64_numpy1.23openssl3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_aarch64_numpy1.23openssl3pyth_h72c8e9e6b0
       linux_ppc64le_numpy1.20openssl1.1.1python3.8.____cpython:
         CONFIG: linux_ppc64le_numpy1.20openssl1.1.1python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -103,11 +98,6 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_ppc64le_numpy1.20openssl1.1.1_h577859b0e0
-      linux_ppc64le_numpy1.20openssl3python3.7.____cpython:
-        CONFIG: linux_ppc64le_numpy1.20openssl3python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_ppc64le_numpy1.20openssl3pyth_h5b231e195e
       linux_ppc64le_numpy1.20openssl3python3.8.____cpython:
         CONFIG: linux_ppc64le_numpy1.20openssl3python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -128,6 +118,16 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_ppc64le_numpy1.21openssl3pyth_h702d2472cc
+      linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython:
+        CONFIG: linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_numpy1.23openssl1.1.1_heeda7f68bb
+      linux_ppc64le_numpy1.23openssl3python3.11.____cpython:
+        CONFIG: linux_ppc64le_numpy1.23openssl3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_numpy1.23openssl3pyth_hf1c296b381
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,10 +8,6 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_numpy1.20openssl1.1.1python3.7.____cpython:
-        CONFIG: osx_64_numpy1.20openssl1.1.1python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.20openssl1.1.1python3_hd47c9492b4
       osx_64_numpy1.20openssl1.1.1python3.8.____cpython:
         CONFIG: osx_64_numpy1.20openssl1.1.1python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -20,10 +16,6 @@ jobs:
         CONFIG: osx_64_numpy1.20openssl1.1.1python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_64_numpy1.20openssl1.1.1python3_h8337850636
-      osx_64_numpy1.20openssl3python3.7.____cpython:
-        CONFIG: osx_64_numpy1.20openssl3python3.7.____cpython
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.20openssl3python3.7.____cpython
       osx_64_numpy1.20openssl3python3.8.____cpython:
         CONFIG: osx_64_numpy1.20openssl3python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -40,6 +32,14 @@ jobs:
         CONFIG: osx_64_numpy1.21openssl3python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_64_numpy1.21openssl3python3.10.____cpython
+      osx_64_numpy1.23openssl1.1.1python3.11.____cpython:
+        CONFIG: osx_64_numpy1.23openssl1.1.1python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_numpy1.23openssl1.1.1python3_ha81386403e
+      osx_64_numpy1.23openssl3python3.11.____cpython:
+        CONFIG: osx_64_numpy1.23openssl3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_numpy1.23openssl3python3.11.____cpython
       osx_arm64_numpy1.20openssl1.1.1python3.8.____cpython:
         CONFIG: osx_arm64_numpy1.20openssl1.1.1python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -64,6 +64,14 @@ jobs:
         CONFIG: osx_arm64_numpy1.21openssl3python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_arm64_numpy1.21openssl3python3._h1dc00f7918
+      osx_arm64_numpy1.23openssl1.1.1python3.11.____cpython:
+        CONFIG: osx_arm64_numpy1.23openssl1.1.1python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_numpy1.23openssl1.1.1pyth_h5cf7f556df
+      osx_arm64_numpy1.23openssl3python3.11.____cpython:
+        CONFIG: osx_arm64_numpy1.23openssl3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_numpy1.23openssl3python3._hb76b6721b1
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -1,0 +1,85 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+davix:
+- '0.8'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+numpy:
+- '1.23'
+openssl:
+- 1.1.1
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- linux-64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -1,0 +1,85 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+davix:
+- '0.8'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+numpy:
+- '1.23'
+openssl:
+- '3'
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- linux-64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -1,0 +1,89 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+davix:
+- '0.8'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+numpy:
+- '1.23'
+openssl:
+- 1.1.1
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- linux-aarch64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_aarch64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -1,0 +1,89 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+davix:
+- '0.8'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+numpy:
+- '1.23'
+openssl:
+- '3'
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- linux-aarch64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -1,0 +1,85 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+davix:
+- '0.8'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+numpy:
+- '1.23'
+openssl:
+- 1.1.1
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- linux-ppc64le
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_ppc64le_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23openssl3python3.11.____cpython.yaml
@@ -1,0 +1,85 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+davix:
+- '0.8'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+numpy:
+- '1.23'
+openssl:
+- '3'
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- linux-ppc64le
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/migrations/python311.yaml
+++ b/.ci_support/migrations/python311.yaml
@@ -1,0 +1,37 @@
+migrator_ts: 1666686085
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython  # new entry
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy
+            - 3.8.* *_73_pypy
+            - 3.9.* *_73_pypy
+    paused: false
+    longterm: True
+    pr_limit: 40
+    max_solver_attempts: 10  # this will make the bot retry "not solvable" stuff 10 times
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+      - cross-python
+      - python_abi
+    exclude_pinned_pkgs: false
+
+python:
+  - 3.11.* *_cpython
+# additional entries to add for zip_keys
+numpy:
+  - 1.23
+python_impl:
+  - cpython

--- a/.ci_support/osx_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -1,0 +1,87 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '14'
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '14'
+davix:
+- '0.8'
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.23'
+openssl:
+- 1.1.1
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- osx-64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/osx_64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -1,0 +1,87 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '14'
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '14'
+davix:
+- '0.8'
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.23'
+openssl:
+- '3'
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- osx-64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/osx_arm64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -1,0 +1,85 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '14'
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '14'
+davix:
+- '0.8'
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.23'
+openssl:
+- 1.1.1
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- osx-arm64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/osx_arm64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -1,0 +1,85 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '14'
+cfitsio:
+- 4.1.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '14'
+davix:
+- '0.8'
+fftw:
+- '3'
+freetype:
+- '2'
+gdk_pixbuf:
+- '2'
+giflib:
+- '5.2'
+glew:
+- '2.1'
+glib:
+- '2'
+graphviz:
+- '6'
+gsl:
+- '2.7'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+libpng:
+- '1.6'
+librsvg:
+- '2'
+libtiff:
+- '4'
+libxml2:
+- '2.10'
+lz4_c:
+- 1.9.3
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.23'
+openssl:
+- '3'
+pcre:
+- '8'
+pin_run_as_build:
+  graphviz:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- osx-arm64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+xrootd:
+- '5'
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/README.md
+++ b/README.md
@@ -59,13 +59,6 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.20openssl1.1.1python3.7.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.20openssl1.1.1python3.7.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_numpy1.20openssl1.1.1python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
@@ -77,13 +70,6 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.20openssl1.1.1python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_numpy1.20openssl3python3.7.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.20openssl3python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -115,10 +101,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.20openssl1.1.1python3.7.____cpython</td>
+              <td>linux_64_numpy1.23openssl1.1.1python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.20openssl1.1.1python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.23openssl1.1.1python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.23openssl3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.23openssl3python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -133,13 +126,6 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.20openssl1.1.1python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_numpy1.20openssl3python3.7.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.20openssl3python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -171,10 +157,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_numpy1.20openssl1.1.1python3.7.____cpython</td>
+              <td>linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.20openssl1.1.1python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.23openssl3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.23openssl3python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -189,13 +182,6 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.20openssl1.1.1python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_ppc64le_numpy1.20openssl3python3.7.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.20openssl3python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -227,10 +213,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.20openssl1.1.1python3.7.____cpython</td>
+              <td>linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.20openssl1.1.1python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.23openssl3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.23openssl3python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -245,13 +238,6 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.20openssl1.1.1python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>osx_64_numpy1.20openssl3python3.7.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.20openssl3python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -280,6 +266,20 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.21openssl3python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.23openssl1.1.1python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.23openssl1.1.1python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.23openssl3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.23openssl3python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -322,6 +322,20 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.21openssl3python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.23openssl1.1.1python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.23openssl1.1.1python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.23openssl3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2612&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/root-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_numpy1.23openssl3python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -155,7 +155,8 @@ requirements:
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
     # Older numba versions have trouble with how LLVM is linked
-    - numba >=0.52  # [py>=37]
+    # numba isn't ready for 3.11 yet
+    - numba >=0.52  # [py>=37 and py<311]
     # Items listed here conflict with ROOT
     - cling 9999
     - root5 9999
@@ -282,7 +283,8 @@ outputs:
         - metakernel
         - ipython
         - notebook
-        - numba  # [py>=37]
+        # numba isn't ready for 3.11 yet
+        - numba  # [py>=37 and py<311]
     test:
       files:
         - test.cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,9 @@ source:
     - patches/0001-Set-LLVM_REQUIRES_EH-for-Cling.patch
     # hack to remove libpython links on macOS
     - no-link-libpython.patch
+    # For Python 3.11
+    - patches/pr-10734.patch
+    - patches/pr-11457.patch
 {% if not builtin_pyroot %}
     - 0001-Support-standalone-pyroot.patch
 {% endif %}

--- a/recipe/patches/pr-10734.patch
+++ b/recipe/patches/pr-10734.patch
@@ -1,0 +1,131 @@
+From a2b916e1dd6406cd9270c4878d932c648698bf02 Mon Sep 17 00:00:00 2001
+From: Enric Tejedor Saavedra <enric.tejedor.saavedra@cern.ch>
+Date: Thu, 9 Jun 2022 12:24:07 +0200
+Subject: [PATCH 1/3] [PyROOT] code.h must not be included directly in 3.11
+
+It has been moved to Include/cpython, and it is included by Python.h.
+
+See:
+https://docs.python.org/3.11/whatsnew/3.11.html
+---
+ bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+index 59997e390d4c..28bbd635c24d 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+@@ -1,10 +1,10 @@
+ // Bindings
+ #include "CPyCppyy.h"
+ #include "structmember.h"    // from Python
+-#if PY_VERSION_HEX >= 0x02050000
+-#include "code.h"            // from Python
+-#else
++#if PY_VERSION_HEX < 0x02050000
+ #include "compile.h"         // from Python
++#elif PY_VERSION_HEX < 0x030b0000
++#include "code.h"            // from Python
+ #endif
+ #ifndef CO_NOFREE
+ // python2.2 does not have CO_NOFREE defined
+
+From 3d8995cc03b1fe6e7e15f8c0963e0b9f82536817 Mon Sep 17 00:00:00 2001
+From: Enric Tejedor Saavedra <enric.tejedor.saavedra@cern.ch>
+Date: Fri, 10 Jun 2022 16:07:10 +0200
+Subject: [PATCH 2/3] [TPython] PySys_SetArgv is deprecated in 3.11
+
+We should use the new PyConfig API of the Python Initialization
+Configuration instead.
+
+See:
+https://docs.python.org/3.11/whatsnew/3.11.html#id7
+---
+ bindings/tpython/src/TPython.cxx | 38 +++++++++++++++++++++++++++-----
+ 1 file changed, 32 insertions(+), 6 deletions(-)
+
+diff --git a/bindings/tpython/src/TPython.cxx b/bindings/tpython/src/TPython.cxx
+index aefd5359f556..9e57cbf4cf29 100644
+--- a/bindings/tpython/src/TPython.cxx
++++ b/bindings/tpython/src/TPython.cxx
+@@ -120,7 +120,37 @@ Bool_t TPython::Initialize()
+ #if PY_VERSION_HEX < 0x03020000
+       PyEval_InitThreads();
+ #endif
++
++// set the command line arguments on python's sys.argv
++#if PY_VERSION_HEX < 0x03000000
++      char *argv[] = {const_cast<char *>("root")};
++#else
++      wchar_t *argv[] = {const_cast<wchar_t *>(L"root")};
++#endif
++      int argc = sizeof(argv) / sizeof(argv[0]);
++#if PY_VERSION_HEX < 0x030b0000
+       Py_Initialize();
++#else
++      PyStatus status;
++      PyConfig config;
++
++      PyConfig_InitPythonConfig(&config);
++
++      status = PyConfig_SetArgv(&config, argc, argv);
++      if (PyStatus_Exception(status)) {
++         PyConfig_Clear(&config);
++         std::cerr << "Error when setting command line arguments." << std::endl;
++         return kFALSE;
++      }
++
++      status = Py_InitializeFromConfig(&config);
++      if (PyStatus_Exception(status)) {
++         PyConfig_Clear(&config);
++         std::cerr << "Error when initializing Python." << std::endl;
++         return kFALSE;
++      }
++      PyConfig_Clear(&config);
++#endif
+ #if PY_VERSION_HEX >= 0x03020000
+ #if PY_VERSION_HEX < 0x03090000
+       PyEval_InitThreads();
+@@ -134,13 +164,9 @@ Bool_t TPython::Initialize()
+          return kFALSE;
+       }
+ 
+-// set the command line arguments on python's sys.argv
+-#if PY_VERSION_HEX < 0x03000000
+-      char *argv[] = {const_cast<char *>("root")};
+-#else
+-      wchar_t *argv[] = {const_cast<wchar_t *>(L"root")};
++#if PY_VERSION_HEX < 0x030b0000
++      PySys_SetArgv(argc, argv);
+ #endif
+-      PySys_SetArgv(sizeof(argv) / sizeof(argv[0]), argv);
+ 
+       // force loading of the ROOT module
+       const int ret = PyRun_SimpleString(const_cast<char *>("import ROOT"));
+
+From 5085bcd47832abfe3070def087d03732118c9175 Mon Sep 17 00:00:00 2001
+From: Enric Tejedor Saavedra <enric.tejedor.saavedra@cern.ch>
+Date: Fri, 10 Jun 2022 16:42:49 +0200
+Subject: [PATCH 3/3] [PyROOT] Prevent cast error when calling PyTuple_SET_ITEM
+ in 3.11
+
+PyTuple_SET_ITEM ends up calling _PyObject_CAST(nullptr) which
+causes "error: invalid cast from type 'std::nullptr_t' to type
+'const PyObject*' {aka 'const _object*'}
+---
+ bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx
+index 685ad3dc6093..21893485944d 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx
+@@ -580,7 +580,7 @@ PyObject* CPyCppyy::CPPMethod::ProcessKeywords(PyObject* self, PyObject* args, P
+ // set all values to zero to be able to check them later (this also guarantees normal
+ // cleanup by the tuple deallocation)
+     for (Py_ssize_t i = 0; i < nArgs+nKeys; ++i)
+-        PyTuple_SET_ITEM(newArgs, i, nullptr);
++        PyTuple_SET_ITEM(newArgs, i, static_cast<PyObject*>(nullptr));
+ 
+ // next, insert the keyword values
+     PyObject *key, *value;

--- a/recipe/patches/pr-11457.patch
+++ b/recipe/patches/pr-11457.patch
@@ -1,0 +1,106 @@
+From e77bcb0fdd0bc622213c33ad7094d28737fe51e7 Mon Sep 17 00:00:00 2001
+From: Enric Tejedor Saavedra <enric.tejedor.saavedra@cern.ch>
+Date: Wed, 28 Sep 2022 14:20:46 +0200
+Subject: [PATCH] [PyROOT] Fixes for garbage collection in Python 3.11
+
+According to the list of changes in Python 3.11:
+
+https://docs.python.org/3.11/whatsnew/3.11.html
+
+types defined with the Py_TPFLAGS_HAVE_GC flag set but with no
+traverse function (PyTypeObject.tp_traverse) will cause an error.
+
+The above is true for a few types that are defined in cppyy.
+This commit removes the aforementioned flag from those type
+definitions with no traverse function. It also sets the right
+flags for the nonified object type; this fixes the teardown GC
+crashes observed when the internal memory management of ROOT
+was involved (e.g. the garbage collection of a tree that belongs
+to a file).
+---
+ .../pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx |  1 -
+ .../cppyy/CPyCppyy/src/CustomPyTypes.cxx      |  3 +--
+ .../cppyy/CPyCppyy/src/MemoryRegulator.cxx    |  3 ++-
+ bindings/pyroot/cppyy/patches/gc_flags.patch  | 26 +++++++++++++++++++
+ 4 files changed, 29 insertions(+), 4 deletions(-)
+ create mode 100644 bindings/pyroot/cppyy/patches/gc_flags.patch
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+index 73fb8099b5dd..f2eea396af1b 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+@@ -764,7 +764,6 @@ PyTypeObject CPPInstance_Type = {
+     0,                             // tp_as_buffer
+     Py_TPFLAGS_DEFAULT |
+         Py_TPFLAGS_BASETYPE |
+-        Py_TPFLAGS_HAVE_GC |
+         Py_TPFLAGS_CHECKTYPES,     // tp_flags
+     (char*)"cppyy object proxy (internal)", // tp_doc
+     0,                             // tp_traverse
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+index 97ce06daa717..ed41b1637c67 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+@@ -78,8 +78,7 @@ PyTypeObject TypedefPointerToClass_Type = {
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     (ternaryfunc)tpc_call,        // tp_call
+     0, 0, 0, 0,
+-    Py_TPFLAGS_DEFAULT |
+-        Py_TPFLAGS_HAVE_GC,       // tp_flags
++    Py_TPFLAGS_DEFAULT,           // tp_flags
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+ #if PY_VERSION_HEX >= 0x02030000
+     , 0                           // tp_del
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
+index f9e92f9c8c1b..510d65f88a8d 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
+@@ -45,7 +45,7 @@ struct InitCPyCppyy_NoneType_t {
+         ((PyVarObject&)CPyCppyy_NoneType).ob_size = 0;
+ 
+         CPyCppyy_NoneType.tp_name        = const_cast<char*>("CPyCppyy_NoneType");
+-        CPyCppyy_NoneType.tp_flags       = Py_TPFLAGS_HAVE_RICHCOMPARE | Py_TPFLAGS_HAVE_GC;
++        CPyCppyy_NoneType.tp_flags       = Py_TPFLAGS_HAVE_RICHCOMPARE;
+ 
+         CPyCppyy_NoneType.tp_traverse    = (traverseproc)0;
+         CPyCppyy_NoneType.tp_clear       = (inquiry)0;
+@@ -135,6 +135,7 @@ bool CPyCppyy::MemoryRegulator::RecursiveRemove(
+             CPyCppyy_NoneType.tp_traverse   = Py_TYPE(pyobj)->tp_traverse;
+             CPyCppyy_NoneType.tp_clear      = Py_TYPE(pyobj)->tp_clear;
+             CPyCppyy_NoneType.tp_free       = Py_TYPE(pyobj)->tp_free;
++            CPyCppyy_NoneType.tp_flags      = Py_TYPE(pyobj)->tp_flags;
+         } else if (CPyCppyy_NoneType.tp_traverse != Py_TYPE(pyobj)->tp_traverse) {
+         // TODO: SystemError?
+             std::cerr << "in CPyCppyy::MemoryRegulater, unexpected object of type: "
+diff --git a/bindings/pyroot/cppyy/patches/gc_flags.patch b/bindings/pyroot/cppyy/patches/gc_flags.patch
+new file mode 100644
+index 000000000000..68f0718629fc
+--- /dev/null
++++ b/bindings/pyroot/cppyy/patches/gc_flags.patch
+@@ -0,0 +1,26 @@
++diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
++index 97ce06daa7..ed41b1637c 100644
++--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
++@@ -78,8 +78,7 @@ PyTypeObject TypedefPointerToClass_Type = {
++     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++     (ternaryfunc)tpc_call,        // tp_call
++     0, 0, 0, 0,
++-    Py_TPFLAGS_DEFAULT |
++-        Py_TPFLAGS_HAVE_GC,       // tp_flags
+++    Py_TPFLAGS_DEFAULT,           // tp_flags
++     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
++ #if PY_VERSION_HEX >= 0x02030000
++     , 0                           // tp_del
++diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
++index f9e92f9c8c..510d65f88a 100644
++--- a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
+++++ b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
++@@ -135,6 +135,7 @@ bool CPyCppyy::MemoryRegulator::RecursiveRemove(
++             CPyCppyy_NoneType.tp_traverse   = Py_TYPE(pyobj)->tp_traverse;
++             CPyCppyy_NoneType.tp_clear      = Py_TYPE(pyobj)->tp_clear;
++             CPyCppyy_NoneType.tp_free       = Py_TYPE(pyobj)->tp_free;
+++            CPyCppyy_NoneType.tp_flags      = Py_TYPE(pyobj)->tp_flags;
++         } else if (CPyCppyy_NoneType.tp_traverse != Py_TYPE(pyobj)->tp_traverse) {
++         // TODO: SystemError?
++             std::cerr << "in CPyCppyy::MemoryRegulater, unexpected object of type: "

--- a/recipe/test_pyroot.py
+++ b/recipe/test_pyroot.py
@@ -2,7 +2,14 @@
 import sys
 import ROOT
 
-if sys.version_info >= (3, 7):
+if sys.version_info >= (3, 11):
+    try:
+        import numba
+    except ImportError:
+        print("Skipping numba test")
+    else:
+        raise RuntimeError("Looks like numba is now supported!")
+elif sys.version_info >= (3, 7):
     @ROOT.Numba.Declare(["float"], "float")
     def fn(x):
         return x**2


### PR DESCRIPTION
Removes the optional numba dependency as that will likely take a few months.