### PR TITLE
Rebuild for linux gcc 11

### DIFF
--- a/.ci_support/linux_64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_64_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20openssl3python3.8.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_64_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20openssl3python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_64_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20openssl3python3.9.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_64_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.20openssl3python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_64_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21openssl3python3.10.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_64_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21openssl3python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_aarch64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -47,7 +47,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_aarch64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_aarch64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -47,7 +47,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_aarch64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_aarch64_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20openssl3python3.8.____cpython.yaml
@@ -47,7 +47,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_aarch64_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20openssl3python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_aarch64_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20openssl3python3.9.____cpython.yaml
@@ -47,7 +47,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_aarch64_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.20openssl3python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_aarch64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -47,7 +47,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_aarch64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_aarch64_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21openssl3python3.10.____cpython.yaml
@@ -47,7 +47,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_aarch64_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21openssl3python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -47,7 +47,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_aarch64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -47,7 +47,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_aarch64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_ppc64le_numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_ppc64le_numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_ppc64le_numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_ppc64le_numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_ppc64le_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20openssl3python3.8.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_ppc64le_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20openssl3python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_ppc64le_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20openssl3python3.9.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_ppc64le_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.20openssl3python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_ppc64le_numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_ppc64le_numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_ppc64le_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21openssl3python3.10.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_ppc64le_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21openssl3python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/linux_ppc64le_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23openssl3python3.11.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/linux_ppc64le_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23openssl3python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 cfitsio:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 davix:
 - '0.8'
 docker_image:

--- a/.ci_support/osx_64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_64_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20openssl3python3.8.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_64_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.20openssl3python3.9.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_64_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21openssl3python3.10.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -43,7 +43,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_arm64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20openssl1.1.1python3.8.____cpython.yaml
@@ -41,7 +41,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_arm64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20openssl1.1.1python3.9.____cpython.yaml
@@ -41,7 +41,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_arm64_numpy1.20openssl3python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20openssl3python3.8.____cpython.yaml
@@ -41,7 +41,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_arm64_numpy1.20openssl3python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.20openssl3python3.9.____cpython.yaml
@@ -41,7 +41,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_arm64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21openssl1.1.1python3.10.____cpython.yaml
@@ -41,7 +41,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_arm64_numpy1.21openssl3python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21openssl3python3.10.____cpython.yaml
@@ -41,7 +41,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_arm64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23openssl1.1.1python3.11.____cpython.yaml
@@ -41,7 +41,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/.ci_support/osx_arm64_numpy1.23openssl3python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23openssl3python3.11.____cpython.yaml
@@ -41,7 +41,7 @@ libpng:
 librsvg:
 - '2'
 libtiff:
-- '4'
+- '4.4'
 libxml2:
 - '2.10'
 lz4_c:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "root" %}
 {% set tag_name = "6-26-10" %}
 {% set version = ".".join(tag_name.split("-")|map("int")|map("string")) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set clang_version = "9.0.1" %}
 {% set clang_patches_version = "root_62600" %}
 


### PR DESCRIPTION
This MR rebuilds this feedstock to pick up the new gcc 11 pin for Linux.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
