### PR TITLE
MNT: Use pixi as conda install tool

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -9,34 +9,24 @@ set -xe
 MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
 MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
 export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
-
-( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
-MICROMAMBA_VERSION="1.5.10-0"
-if [[ "$(uname -m)" == "arm64" ]]; then
-  osx_arch="osx-arm64"
-else
-  osx_arch="osx-64"
+( startgroup "Provisioning base env with pixi" ) 2> /dev/null
+mkdir -p "${MINIFORGE_HOME}"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
 fi
-MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
-MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
-echo "Downloading micromamba ${MICROMAMBA_VERSION}"
-micromamba_exe="$(mktemp -d)/micromamba"
-curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
-chmod +x "${micromamba_exe}"
+sed -i.bak "s/platforms = .*/platforms = [\"osx-${arch}\"]/" pixi.toml
 echo "Creating environment"
-"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
-  --channel conda-forge \
-  pip rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
-echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
-mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
-echo "Cleaning up micromamba"
-rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
-( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
+pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+( endgroup "Provisioning base env with pixi" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-echo "Activating environment"
-source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
-conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -9,7 +9,7 @@ conda_build:
   pkg_format: '2'
 conda_build_tool: rattler-build
 conda_forge_output_validation: true
-conda_install_tool: micromamba
+conda_install_tool: pixi
 github:
   branch_name: main
   tooling_branch_name: main

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,167 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "root-feedstock"
+version = "3.51.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/root-feedstock"
+authors = ["@conda-forge/root"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-64", "osx-arm64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build root-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_python3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
+description = "Build root-feedstock with variant linux_64_python3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_python3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_64_python3.10.____cpython"
+[tasks."build-linux_64_python3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
+description = "Build root-feedstock with variant linux_64_python3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_python3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_64_python3.11.____cpython"
+[tasks."build-linux_64_python3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
+description = "Build root-feedstock with variant linux_64_python3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_python3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_64_python3.12.____cpython"
+[tasks."build-linux_64_python3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
+description = "Build root-feedstock with variant linux_64_python3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_64_python3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
+description = "List contents of root-feedstock packages built for variant linux_64_python3.13.____cp313"
+[tasks."build-linux_64_python3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.9.____cpython.yaml"
+description = "Build root-feedstock with variant linux_64_python3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_python3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.9.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_64_python3.9.____cpython"
+[tasks."build-linux_aarch64_python3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.10.____cpython.yaml"
+description = "Build root-feedstock with variant linux_aarch64_python3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.10.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_aarch64_python3.10.____cpython"
+[tasks."build-linux_aarch64_python3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
+description = "Build root-feedstock with variant linux_aarch64_python3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_aarch64_python3.11.____cpython"
+[tasks."build-linux_aarch64_python3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
+description = "Build root-feedstock with variant linux_aarch64_python3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_aarch64_python3.12.____cpython"
+[tasks."build-linux_aarch64_python3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
+description = "Build root-feedstock with variant linux_aarch64_python3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
+description = "List contents of root-feedstock packages built for variant linux_aarch64_python3.13.____cp313"
+[tasks."build-linux_aarch64_python3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.9.____cpython.yaml"
+description = "Build root-feedstock with variant linux_aarch64_python3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.9.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_aarch64_python3.9.____cpython"
+[tasks."build-linux_ppc64le_python3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.10.____cpython.yaml"
+description = "Build root-feedstock with variant linux_ppc64le_python3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_python3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.10.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_ppc64le_python3.10.____cpython"
+[tasks."build-linux_ppc64le_python3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.11.____cpython.yaml"
+description = "Build root-feedstock with variant linux_ppc64le_python3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_python3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.11.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_ppc64le_python3.11.____cpython"
+[tasks."build-linux_ppc64le_python3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.12.____cpython.yaml"
+description = "Build root-feedstock with variant linux_ppc64le_python3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_python3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.12.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_ppc64le_python3.12.____cpython"
+[tasks."build-linux_ppc64le_python3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.13.____cp313.yaml"
+description = "Build root-feedstock with variant linux_ppc64le_python3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_python3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.13.____cp313.yaml"
+description = "List contents of root-feedstock packages built for variant linux_ppc64le_python3.13.____cp313"
+[tasks."build-linux_ppc64le_python3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.9.____cpython.yaml"
+description = "Build root-feedstock with variant linux_ppc64le_python3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_python3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.9.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant linux_ppc64le_python3.9.____cpython"
+[tasks."build-osx_arm64_python3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
+description = "Build root-feedstock with variant osx_arm64_python3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant osx_arm64_python3.10.____cpython"
+[tasks."build-osx_arm64_python3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
+description = "Build root-feedstock with variant osx_arm64_python3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant osx_arm64_python3.11.____cpython"
+[tasks."build-osx_arm64_python3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
+description = "Build root-feedstock with variant osx_arm64_python3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant osx_arm64_python3.12.____cpython"
+[tasks."build-osx_arm64_python3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
+description = "Build root-feedstock with variant osx_arm64_python3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
+description = "List contents of root-feedstock packages built for variant osx_arm64_python3.13.____cp313"
+[tasks."build-osx_arm64_python3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.9.____cpython.yaml"
+description = "Build root-feedstock with variant osx_arm64_python3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.9.____cpython.yaml"
+description = "List contents of root-feedstock packages built for variant osx_arm64_python3.9.____cpython"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: root
   tag_name: 6-34-06
-  build_number: 0
+  build_number: 1
   clang_version: 18.1.8
   clang_patches_version: root_63406
   builtin_pyroot: true


### PR DESCRIPTION
* Use pixi as the install tool for faster builds and better local support.
* Bump build number.
* MNT: Re-rendered with conda-build 25.5.0, conda-smithy 3.51.1, and conda-forge-pinning 2025.07.24.10.11.14


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
