### PR TITLE
Test build of 6.34.x in isolation

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: root
   tag_name: 6-34-06
-  build_number: 1
+  build_number: 2
   clang_version: 18.1.8
   clang_patches_version: root_63406
   builtin_pyroot: true


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I would like to understand if the following build failures
```
thread 'tokio-runtime-worker' panicked at /home/conda/feedstock_root/build_artifacts/bld/rattler-build_rattler-build_1750800802/build_env/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/time/entry.rs:557:9:
A Tokio 1.x context was found, but it is being shutdown.
```
Caused by the `pixi` installer as found in https://github.com/conda-forge/root-feedstock/pull/301 e.g. at https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1300435&view=logs&j=909f4845-68df-5ef3-2394-13fe1d1aa0d0&t=b49dd133-34b8-5aa1-8802-8c471cd86e29&l=1825 only on the MacOS/Linux ARM64 Python3.13 runners are reproducible in isolation.

Note that I rerendered the branch locally but conda-smithy says there is nothing to do