### PR TITLE
Remove runtime dependency on compilers package

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: root
   tag_name: 6-40-00
-  build_number: 3
+  build_number: 4
   clang_version: 20.1.8
   clang_patches_version: root_64000
   builtin_clang: false
@@ -239,7 +239,6 @@ outputs:
         - ${{ pin_subpackage('root_base', exact=True) }}
         - root_cxx_standard ==${{ root_cxx_std }}
         - python
-        - compilers  # This package is hostile to how conda-build manages compilers
         - metakernel
         - ipython
         - notebook


### PR DESCRIPTION
This is labeled as "hostile" and there is no concrete documentation on why we should have it, so let's try removing it.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
